### PR TITLE
Use named pipe for uninstall coordination

### DIFF
--- a/block-ads-ui/utils/utils.go
+++ b/block-ads-ui/utils/utils.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
+	"time"
 	"unicode/utf16"
 	"unsafe"
 
@@ -20,12 +20,7 @@ const (
 	th32csSnapProcess = 0x00000002
 	processTerminate  = 0x0001
 
-	shmNameLocal  = "block-ads-unins"         // 共享内存名（同会话）
-	shmNameGlobal = "Global\\block-ads-unins" // 跨会话共享内存名
-	shmSize       = 4096                      // 4KB就够用了
-	pageReadWrite = 0x04                      // PAGE_READWRITE
-	fileMapWrite  = 0x0002                    // FILE_MAP_WRITE
-	fileMapRead   = 0x0004                    // FILE_MAP_READ
+	pipeName = `\\\\.\\pipe\\block-ads-unins`
 )
 
 var (
@@ -39,16 +34,7 @@ var (
 
 	// 删除文件相关
 	procDeleteFileW = modKernel32.NewProc("DeleteFileW")
-
-	// 共享内存相关
-	procCreateFileMappingW = modKernel32.NewProc("CreateFileMappingW")
-	procOpenFileMappingW   = modKernel32.NewProc("OpenFileMappingW")
-	procMapViewOfFile      = modKernel32.NewProc("MapViewOfFile")
-	procUnmapViewOfFile    = modKernel32.NewProc("UnmapViewOfFile")
 )
-
-// 写共享内存锁
-var shmMu sync.Mutex
 
 // PROCESSENTRY32 结构
 type processEntry32 struct {
@@ -64,128 +50,42 @@ type processEntry32 struct {
 	SzExeFile           [260]uint16
 }
 
-// 把卸载程序文件名写入共享内存，供 block-ads.exe 读取并临时放行
-// 约定：共享内存中存的是 UTF-8 文本，按换行符分隔多个文件名
-func addUnWithName(name, shmName string) error {
+func sndUn(name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
+		return fmt.Errorf("空卸载名")
+	}
+	name = filepath.Base(name)
+	if name == "." || name == "" {
 		return fmt.Errorf("空卸载名")
 	}
 	if strings.ContainsAny(name, "\r\n") {
 		return fmt.Errorf("卸载名包含非法字符")
 	}
 
-	shmMu.Lock()
-	defer shmMu.Unlock()
-
-	nm, err := syscall.UTF16PtrFromString(shmName)
+	h, err := syscall.CreateFile(
+		syscall.StringToUTF16Ptr(pipeName),
+		syscall.GENERIC_WRITE,
+		0,
+		nil,
+		syscall.OPEN_EXISTING,
+		0,
+		0,
+	)
 	if err != nil {
 		return err
 	}
+	defer syscall.CloseHandle(h)
 
-	// 先尝试打开已有的文件映射
-	h, _, e := procOpenFileMappingW.Call(
-		uintptr(fileMapRead|fileMapWrite),
-		0,
-		uintptr(unsafe.Pointer(nm)),
-	)
-	if h == 0 {
-		// 没有就创建新的共享内存（基于系统分页文件）
-		h, _, e = procCreateFileMappingW.Call(
-			uintptr(syscall.InvalidHandle), // 使用系统分页文件
-			0,
-			uintptr(pageReadWrite),
-			0,
-			uintptr(shmSize),
-			uintptr(unsafe.Pointer(nm)),
-		)
-		if h == 0 {
-			if e != nil && e != syscall.Errno(0) {
-				return fmt.Errorf("CreateFileMappingW: %v", e)
-			}
-			return fmt.Errorf("CreateFileMappingW 失败")
-		}
+	b := []byte(strings.ToLower(name))
+	var n uint32
+	if err = syscall.WriteFile(h, b, &n, nil); err != nil {
+		return err
 	}
-	defer syscall.CloseHandle(syscall.Handle(h))
-
-	// 映射视图
-	addr, _, e2 := procMapViewOfFile.Call(
-		h,
-		uintptr(fileMapRead|fileMapWrite),
-		0,
-		0,
-		uintptr(shmSize),
-	)
-	if addr == 0 {
-		if e2 != nil && e2 != syscall.Errno(0) {
-			return fmt.Errorf("MapViewOfFile: %v", e2)
-		}
-		return fmt.Errorf("MapViewOfFile 失败")
+	if int(n) != len(b) {
+		return fmt.Errorf("写入不完整")
 	}
-	defer procUnmapViewOfFile.Call(addr)
-
-	buf := unsafe.Slice((*byte)(unsafe.Pointer(addr)), shmSize)
-
-	// 读现有内容（到第一个 0 字节为止）
-	end := 0
-	for end < len(buf) && buf[end] != 0 {
-		end++
-	}
-
-	cur := ""
-	if end > 0 {
-		cur = string(buf[:end])
-	}
-
-	// 用 map 去重
-	set := make(map[string]struct{})
-	if cur != "" {
-		for _, ln := range strings.Split(cur, "\n") {
-			ln = strings.TrimSpace(ln)
-			if ln == "" {
-				continue
-			}
-			set[ln] = struct{}{}
-		}
-	}
-	set[name] = struct{}{} // 加入本次的卸载器文件名
-
-	// 重新拼成字符串
-	var sb strings.Builder
-	first := true
-	for k := range set {
-		if !first {
-			sb.WriteByte('\n')
-		}
-		sb.WriteString(k)
-		first = false
-	}
-	out := sb.String()
-
-	// 太长就简单降级，只保留当前这个
-	if len(out) >= shmSize {
-		out = name
-	}
-
-	// 清零再写
-	for i := range buf {
-		buf[i] = 0
-	}
-	copy(buf, []byte(out))
-
 	return nil
-}
-
-func addUn(name string) error {
-	var lastErr error
-	for _, shmName := range []string{shmNameGlobal, shmNameLocal} {
-		if err := addUnWithName(name, shmName); err == nil {
-			return nil
-		} else {
-			lastErr = err
-		}
-	}
-	return lastErr
 }
 
 func Kill(exeName string) error {
@@ -558,11 +458,10 @@ func Tryrm(exePath string) error {
 			return fmt.Errorf("空卸载路径")
 		}
 
-		// 先把卸载程序文件名写入共享内存，让 block-ads.exe 临时放行
-		if err := addUn(filepath.Base(p)); err != nil {
-			// 不影响卸载流程，只打印一下
-			fmt.Println("addUn err:", err)
+		if err := sndUn(filepath.Base(p)); err != nil {
+			fmt.Println("sndUn err:", err)
 		}
+		time.Sleep(500 * time.Millisecond)
 
 		var e1, e2, e3 error
 


### PR DESCRIPTION
## Summary
- replace uninstall whitelist shared memory handling with a named pipe listener in block-ads
- send found uninstaller names to block-ads from the UI and wait briefly before execution

## Testing
- go test ./... *(fails: windows-specific modules are unavailable in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920512e02a883279a2f6e8e7b739e17)